### PR TITLE
feat: Add GitHub Actions workflow for release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release Binaries
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create a release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24' # Specify your Go version
+
+      - name: Build for Linux (amd64)
+        run: GOOS=linux GOARCH=amd64 go build -o dlookup-linux-amd64 main.go
+      - name: Build for Linux (arm64)
+        run: GOOS=linux GOARCH=arm64 go build -o dlookup-linux-arm64 main.go
+      - name: Build for macOS (amd64)
+        run: GOOS=darwin GOARCH=amd64 go build -o dlookup-macos-amd64 main.go
+      - name: Build for macOS (arm64)
+        run: GOOS=darwin GOARCH=arm64 go build -o dlookup-macos-arm64 main.go
+      - name: Build for Windows (amd64)
+        run: GOOS=windows GOARCH=amd64 go build -o dlookup-windows-amd64.exe main.go
+      - name: Build for Windows (arm64)
+        run: GOOS=windows GOARCH=arm64 go build -o dlookup-windows-arm64.exe main.go
+
+      - name: Create Release and Upload Binaries
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dlookup-linux-amd64
+            dlookup-linux-arm64
+            dlookup-macos-amd64
+            dlookup-macos-arm64
+            dlookup-windows-amd64.exe
+            dlookup-windows-arm64.exe
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -33,18 +33,30 @@ A terminal-based application built with Go and Bubble Tea for performing various
 
 ## Installation
 
+### From GitHub Releases
+
+Pre-compiled binaries for various operating systems and architectures are available on the [GitHub Releases page](https://github.com/kristiand00/dlookup/releases).
+
+1. Go to the [Releases page](https://github.com/kristiand00/dlookup/releases).
+2. Download the appropriate binary for your system (e.g., `dlookup-linux-amd64`, `dlookup-windows-amd64.exe`).
+3. (Optional but recommended) Rename the downloaded file to `dlookup` (or `dlookup.exe` on Windows) for easier use.
+4. Make the binary executable (on Linux/macOS): `chmod +x dlookup`
+5. You can now run the application, e.g., `./dlookup` or add it to your system's PATH.
+
+### From Source
+
 1.  **Clone the repository:**
     ```bash
     git clone https://github.com/kristiand00/dlookup.git
     cd dlookup
     ```
 
-2.  **Get Dependencies:**
+2.  **Get Dependencies (if building from source):**
     ```bash
     go mod tidy
     ```
 
-3.  **Build the binary:**
+3.  **Build the binary (if building from source):**
     ```bash
     go build -o dlookup .
     ```


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the building and releasing of binaries for dlookup.

Key changes:
- Added `.github/workflows/release.yml`:
    - Triggers on new tags matching `v*.*.*`.
    - Sets up Go 1.24.
    - Builds binaries for Linux (amd64, arm64), macOS (amd64, arm64), and Windows (amd64, arm64).
    - Creates a GitHub release and uploads the compiled binaries as assets.
- Updated `README.md`:
    - Added a new "From GitHub Releases" section under "Installation" to guide you on downloading and using pre-compiled binaries.

To test this workflow:
1. Merge these changes.
2. Create and push a test tag (e.g., `git tag v0.0.1-test && git push origin v0.0.1-test`).
3. Observe the "Release Binaries" action run on the GitHub Actions page.
4. Verify that a new release is created with the binaries attached.